### PR TITLE
Adding better negative and prefix support

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "harvest-profit-ui",
-  "version": "1.0.0-alpha.9",
+  "version": "1.0.0-alpha.10",
   "description": "Harvest Profit UI Components",
   "main": "dist/index.js",
   "repository": "https://github.com/HarvestProfit/harvest-profit-ui",

--- a/src/forms/InputNumeric.js
+++ b/src/forms/InputNumeric.js
@@ -69,6 +69,10 @@ export default class InputNumeric extends PureComponent {
     let newValue = event.target.value;
     if (this.props.allowNegative) {
       newValue = newValue.replace(/[^0-9.-]/g, '');
+      if (/[-]/g.test(`${newValue}`)) {
+        newValue = newValue.replace(/[-]/g, '');
+        newValue = `-${newValue}`;
+      }
     } else {
       newValue = newValue.replace(/[^0-9.]/g, '');
     }
@@ -100,13 +104,19 @@ export default class InputNumeric extends PureComponent {
     let value = this.props.defaultValue;
     if (!this.state.isFocused) {
       const checkedValue = toNumber(value);
+      let negative = '';
       if (isFinite(checkedValue)) {
         value = checkedValue.toFixed(this.props.decimalPlaces);
       }
       if (this.props.commaSeparator) {
         value = NumbersHelper.numberWithCommas(value);
       }
-      value = `${this.props.prefix}${value}`;
+      if (this.props.allowNegative && checkedValue < 0) {
+        value = value.replace(/[-]/g, '');
+        negative = '-';
+      }
+
+      value = `${negative}${this.props.prefix}${value}`;
     }
 
     return (

--- a/src/forms/InputNumeric.md
+++ b/src/forms/InputNumeric.md
@@ -44,3 +44,24 @@ initialState = { value: '2001' };
 </div>
 
 ```
+
+And allow negative numbers
+
+```js
+initialState = { value: '4242' };
+
+<div>
+  <InputNumeric
+    commaSeparator
+    decimalPlaces={2}
+    defaultValue={state.value}
+    onChange={(value) => setState({ value })}
+    prefix="$"
+    allowNegative
+  />
+  <p>
+    Current Value: <code>{state.value}</code>
+  </p>
+</div>
+
+```

--- a/src/utilities/NumbersHelper.js
+++ b/src/utilities/NumbersHelper.js
@@ -18,6 +18,17 @@ export default class NumbersHelper {
     return parts.join('.');
   }
 
+  static applyPrefix = (number, prefix) => {
+    let newNumber = number;
+    let negative = '';
+    if (/[-]/g.test(`${newNumber}`)) {
+      newNumber = newNumber.replace(/[-]/g, '');
+      negative = '-';
+    }
+
+    return `${negative}${prefix}${newNumber}`;
+  }
+
 
   /**
    * Formats a number to a short format with:

--- a/test/forms/InputNumeric.test.js
+++ b/test/forms/InputNumeric.test.js
@@ -134,6 +134,23 @@ describe('<InputNumeric />', () => {
     expect(onChange.mock.calls[0][0]).toEqual('-123');
   });
 
+  it('should allow you to enter a negative number with a prefix and the sign in front of the prefix', () => {
+    const input = shallow(
+      <InputNumeric
+        allowNegative
+        commaSeparator
+        decimalPlaces={2}
+        defaultValue={-1230}
+        onChange={() => {}}
+        prefix="$"
+      />);
+
+    input.simulate('focus');
+    expect(input.props().value).toEqual(-1230);
+    input.simulate('blur');
+    expect(input.props().value).toEqual('-$1,230.00');
+  });
+
   it('should add a "0" in front of a plain decimal "."', () => {
     const onChange = jest.fn();
     const input = shallow(

--- a/test/utilities/NumbersHelper.js
+++ b/test/utilities/NumbersHelper.js
@@ -28,6 +28,18 @@ describe('NumbersHelper', () => {
     });
   });
 
+  describe('applyPrefix', () => {
+    it('should put a prefix in front of the number', () => {
+      const number = NumbersHelper.applyPrefix(NumbersHelper.numberWithCommas(1000), '$');
+      expect(number).toEqual('$1,000');
+    });
+
+    it('should put a prefix in front of the number with the sign in front of the prefix', () => {
+      const number = NumbersHelper.applyPrefix(NumbersHelper.numberWithCommas(-1000), '$');
+      expect(number).toEqual('-$1,000');
+    });
+  });
+
   describe('formatToShortNumber', () => {
     it('should convert a hundreds number into itself', () => {
       const shortNumber = NumbersHelper.formatToShortNumber(100);


### PR DESCRIPTION
Numeric inputs have better negative support.  Negative signs will show up in front of the prefix now.  Also it only allows one negative sign, before you could type in a bunch.  Also adds `applyPrefix` to the numbers helper module that will apply a prefix to the number, if the number is negative, the sign will be placed in front of the prefix.