### PR TITLE
Fixes numeric input formatting

### DIFF
--- a/src/inputs/InputNumeric.js
+++ b/src/inputs/InputNumeric.js
@@ -59,10 +59,26 @@ export default class InputNumeric extends PureComponent {
 
   handleBlur() {
     this.setState({ isFocused: false });
+    this.props.onChange(this.prepareNumber());
   }
 
   handleFocus() {
     this.setState({ isFocused: true });
+    this.props.onChange(this.prepareNumber());
+  }
+
+  prepareNumber() {
+    let { value } = this.props;
+    if (this.props.decimalPlaces > 0) {
+      const checkedValue = toNumber(value);
+      if (isFinite(checkedValue)) {
+        const stringValue = checkedValue.toFixed(this.props.decimalPlaces);
+        const [valueAfterDecimal] = stringValue.match(/\.\d*/);
+        value = `${value}`.replace(/\.\d*/, '');
+        value = `${value}${valueAfterDecimal}`;
+      }
+    }
+    return value;
   }
 
   handleChange(event) {

--- a/src/inputs/InputNumeric.md
+++ b/src/inputs/InputNumeric.md
@@ -1,7 +1,7 @@
 Simple numeric input example:
 
 ```js
-initialState = { value: '4242' };
+initialState = { value: '4242.125' };
 
 <div>
   <InputNumeric


### PR DESCRIPTION
If you have a long decimal number, on focus the first time it will show all of the decimals instead of the specified amount.  This ensures that if you specify 2 decimals, there will always be 2 decimals after the number.  This only changes on blur and focus so typing is not messed up.  