### PR TITLE
Fix bad class names

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "react-dom": "^0.14.9 || ^15.3.0 || ^16.0.0"
   },
   "dependencies": {
-    "bootstrap": "^4.1.2",
+    "bootstrap": "^4.3.1",
     "font-awesome": "^4.7.0",
     "lodash": "^4.17.5",
     "lodash.isfinite": "^3.3.2",

--- a/scss/Dropdown.scss
+++ b/scss/Dropdown.scss
@@ -12,20 +12,6 @@ $dropdown-menu-v2-option-border: $white;
 $dropdown-menu-v2-placeholder-color: #aaaaaa;
 $dropdown-menu-v2-group-background-color: darken($light-white, 3%);
 
-.dropdown-toggle.v2 {
-  display: flex;
-  flex-flow: column;
-
-  &::after {
-    display: none;
-  }
-
-  button.no-selection {
-    color: $dropdown-menu-v2-placeholder-color;
-    font-style: italic;
-  }
-}
-
 .dropdown-menu.v2 {
   outline: none;
   overflow: hidden;

--- a/src/dropdowns/SearchableDropdownBase.js
+++ b/src/dropdowns/SearchableDropdownBase.js
@@ -355,7 +355,7 @@ export default class SearchableDropdownBase extends PureComponent {
           isOpen={this.state.open}
           toggle={this.toggleOpen}
         >
-          <DropdownToggle tag="div" className="dropdown-toggle v2">
+          <DropdownToggle tag="div" caret={false}>
             <DropdownToggleComponent
               selectedValue={selectedValueText}
               hasSelection={hasSelection}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1974,10 +1974,10 @@ boolbase@~1.0.0:
   resolved "https://registry.yarnpkg.com/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
   integrity sha1-aN/1++YMUes3cl6p4+0xDcwed24=
 
-bootstrap@^4.1.2:
-  version "4.1.3"
-  resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-4.1.3.tgz#0eb371af2c8448e8c210411d0cb824a6409a12be"
-  integrity sha512-rDFIzgXcof0jDyjNosjv4Sno77X4KuPeFxG2XZZv1/Kc8DRVGVADdoQyyOVDwPqL36DDmtCQbrpMCqvpPLJQ0w==
+bootstrap@^4.3.1:
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-4.3.1.tgz#280ca8f610504d99d7b6b4bfc4b68cec601704ac"
+  integrity sha512-rXqOmH1VilAt2DyPzluTi2blhk17bO7ef+zLLPlWvG494pDxcM234pJ8wTc/6R40UWizAIIMgxjvxZg5kmsbag==
 
 brace-expansion@^1.1.7:
   version "1.1.11"


### PR DESCRIPTION
Removes invalid class names that conflict with bootstrap, and bumps the bootstrap version.

I'm sure there are other collisions in here, but this particular collision was actually set via a boolean attribute in reactstrap.